### PR TITLE
feat: 메인 페이지 태그 필터 기능 및 TagFilter 컴포넌트 추가

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,46 +1,128 @@
-import { allPosts } from '@/.contentlayer/generated';
+import { allPosts, Post } from '@/.contentlayer/generated';
+import TagFilter, { TagOption } from '@/components/tag-filter';
 import PostCard from '@/components/post-card';
 import Pagination from '@/components/pagination';
 
-export default async function Home() {
+type HomeProps = {
+  searchParams?: {
+    tag?: string;
+  };
+};
+
+type PostWithNormalizedTags = Post & {
+  normalizedTags: string[];
+};
+
+const normalizeTags = (tags: Post['tags']): string[] => {
+  if (!tags) {
+    return [];
+  }
+
+  return tags
+    .flatMap((tag) => tag.split(','))
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+};
+
+const buildTagOptions = (posts: PostWithNormalizedTags[]): TagOption[] => {
+  const tagMap = new Map<string, { label: string; count: number }>();
+
+  posts.forEach((post) => {
+    post.normalizedTags.forEach((tag) => {
+      const key = tag.toLowerCase();
+      const existing = tagMap.get(key);
+
+      if (existing) {
+        existing.count += 1;
+      } else {
+        tagMap.set(key, { label: tag, count: 1 });
+      }
+    });
+  });
+
+  const tagOptions = Array.from(tagMap.values()).sort((a, b) =>
+    a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+  );
+
+  return [{ label: 'All', count: posts.length }, ...tagOptions];
+};
+
+const getSelectedTag = (tagOptions: TagOption[], searchParamTag?: string): string => {
+  if (!searchParamTag) {
+    return 'All';
+  }
+
+  const normalized = searchParamTag.toLowerCase();
+
+  const matchingTag = tagOptions.find(
+    (tag) => tag.label.toLowerCase() === normalized
+  );
+
+  return matchingTag ? matchingTag.label : 'All';
+};
+
+export default async function Home({ searchParams }: HomeProps) {
   const sortedPosts = allPosts.sort(
     (a, b) =>
       new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
   );
 
-  const featuredPost = sortedPosts[0];
-  const remainingPosts = sortedPosts.slice(1);
-  
-  // Pagination logic
+  const postsWithTags: PostWithNormalizedTags[] = sortedPosts.map((post) => ({
+    ...post,
+    normalizedTags: normalizeTags(post.tags),
+  }));
+
+  const tagOptions = buildTagOptions(postsWithTags);
+  const selectedTag = getSelectedTag(tagOptions, searchParams?.tag);
+  const normalizedSelectedTag = selectedTag.toLowerCase();
+
+  const filteredPosts =
+    normalizedSelectedTag === 'all'
+      ? postsWithTags
+      : postsWithTags.filter((post) =>
+          post.normalizedTags.some(
+            (tag) => tag.toLowerCase() === normalizedSelectedTag
+          )
+        );
+
+  const featuredPost = filteredPosts[0];
+  const remainingPosts = filteredPosts.slice(1);
+
   const postsPerPage = 10;
   const currentPagePosts = remainingPosts.slice(0, postsPerPage);
   const totalPages = Math.ceil(remainingPosts.length / postsPerPage);
 
   return (
     <div className="space-y-8">
-      {/* Page Title */}
       <div className="space-y-1 pt-1 pb-5">
         <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-[#252B52] dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14">
           ALL POSTS
         </h1>
       </div>
 
-      {/* Featured Post */}
-      {featuredPost && (
+      <TagFilter tags={tagOptions} selectedTag={selectedTag} />
+
+      {featuredPost ? (
         <div className="mb-8">
           <PostCard post={featuredPost} size="featured" key={featuredPost._id} />
         </div>
+      ) : (
+        <p className="text-sm text-[#252B52]/80 dark:text-gray-300">
+          아직 해당 태그로 작성된 글이 없습니다.
+        </p>
       )}
 
-      {/* Remaining Posts Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {currentPagePosts.map((post) => (
-          <PostCard post={post} size="grid" key={post._id} />
-        ))}
-      </div>
+      {currentPagePosts.length > 0 && (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {currentPagePosts.map((post) => (
+            <PostCard post={post} size="grid" key={post._id} />
+          ))}
+        </div>
+      )}
 
-      {/* Pagination */}
-      <Pagination currentPage={1} totalPages={totalPages} />
+      {totalPages > 0 && (
+        <Pagination currentPage={1} totalPages={totalPages} />
+      )}
     </div>
   );
 }

--- a/components/tag-filter.tsx
+++ b/components/tag-filter.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+
+export type TagOption = {
+  label: string;
+  count: number;
+};
+
+interface TagFilterProps {
+  tags: TagOption[];
+  selectedTag: string;
+}
+
+export default function TagFilter({ tags, selectedTag }: TagFilterProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {tags.map(({ label, count }) => {
+        const isAll = label.toLowerCase() === 'all';
+        const isSelected = label.toLowerCase() === selectedTag.toLowerCase();
+        const href = isAll ? '/' : `/?tag=${encodeURIComponent(label)}`;
+
+        return (
+          <Link
+            key={label}
+            href={href}
+            className={clsx(
+              'rounded-full border px-4 py-2 text-sm font-medium transition-colors duration-200',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#252B52] dark:focus-visible:ring-[#F9F7F6]',
+              'text-[#252B52] dark:text-[#F9F7F6] border-[#252B52]/20 dark:border-[#F9F7F6]/20 hover:bg-[#252B52]/10 dark:hover:bg-[#F9F7F6]/10',
+              {
+                'bg-[#252B52] text-[#F9F7F6] border-[#252B52] hover:bg-[#252B52] dark:bg-[#F9F7F6] dark:text-[#252B52] dark:border-[#F9F7F6] dark:hover:bg-[#F9F7F6]': isSelected,
+              }
+            )}
+            aria-current={isSelected ? 'page' : undefined}
+          >
+            {label} <span className="text-xs">({count})</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
메인 페이지에서 포스트를 태그별로 필터링할 수 있는 기능을 추가하고, 태그 목록을 pill 형태로 렌더링하는 `TagFilter` 컴포넌트를 새로 도입.
선택된 태그는 URL 쿼리 파라미터(`?tag=`)로 반영되어 새로고침이나 공유 시에도 동일한 필터 상태 유지.

## 변경사항

- `app/(main)/page.tsx`
  - 전체 페이지 구조를 태그 필터 중심으로 리팩터링
  - 태그 정규화, 선택된 태그 계산, `searchParams` 기반의 필터링 로직 추가
  - 태그가 없는 경우 안내 메시지를 표시하도록 조건부 렌더링 추가

- `components/tag-filter.tsx`
  - 태그 목록을 pill 형태로 렌더링하는 재사용 가능한 `TagFilter` 컴포넌트 추가
  - 현재 선택된 태그를 시각적으로 구분
  - `/` 또는 /`?tag=...` 링크를 자동으로 생성하여 라우팅 처리

## 주요 기능

- `All` 태그 선택 시 전체 포스트 노출

- 특정 태그 선택 시 해당 태그를 포함한 포스트만 표시

- 선택된 태그를 URL 쿼리 파라미터(`?tag=`)로 반영

- 태그가 없을 경우 안내 메시지 표시

- 태그 pill은 줄바꿈(flex-wrap)으로 다중 행 표시 지원
